### PR TITLE
Use proxy for blizz api

### DIFF
--- a/src/client/components/home/home.js
+++ b/src/client/components/home/home.js
@@ -4,13 +4,12 @@ import useClient from "../../hooks";
 import { filter } from "lodash";
 import { LadderTable } from "Components";
 import { getLadderData } from "./selectors";
+import StyledHome from "./style";
 
 export const Home = () => {
   const [race, setRace] = useState("Zerg");
   const [filteredData, setFilteredData] = useState([]);
-  const { loading, data } = useClient(
-    "https://us.api.blizzard.com/sc2/ladder/grandmaster/3"
-  );
+  const { loading, data } = useClient("/sc2/ladder/grandmaster/3");
 
   useEffect(() => {
     if (data) {
@@ -27,20 +26,17 @@ export const Home = () => {
     }
   }, [data, race]);
 
-  return loading ? (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        height: "100vh",
-      }}
-    >
-      <CircularProgress />
-    </div>
-  ) : (
-    <div>
-      <LadderTable rows={filteredData} />
-    </div>
+  return (
+    <StyledHome>
+      {loading ? (
+        <div className="loadingContainer">
+          <CircularProgress />
+        </div>
+      ) : (
+        <div>
+          <LadderTable rows={filteredData} />
+        </div>
+      )}
+    </StyledHome>
   );
 };

--- a/src/client/components/home/selectors.js
+++ b/src/client/components/home/selectors.js
@@ -1,7 +1,6 @@
 import { get, map } from "lodash";
 
 export const getLadderData = (result) => {
-  console.log("???", result);
   return map(result.ladderTeams, (res) => ({
     name: get(res, "teamMembers[0].displayName"),
     clanTag: get(res, "teamMembers[0].clanTag"),

--- a/src/client/components/home/style.js
+++ b/src/client/components/home/style.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+const StyledHome = styled.div`
+  .loadingContainer {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    height: 100vh;
+  }
+`;
+export default StyledHome;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -2,11 +2,7 @@ const YAML = require("yaml");
 const fs = require("fs");
 const express = require("express");
 const app = express();
-const {
-  ClientCredentials,
-  ResourceOwnerPassword,
-  AuthorizationCode,
-} = require("simple-oauth2");
+const { ClientCredentials } = require("simple-oauth2");
 const port = 3002;
 var path = require("path");
 


### PR DESCRIPTION
## Major Changes
- link passed to useClient now does not include a direct reference to the blizz api
- Removed inline style, console log, unused imports

## Tests for functionality
- In the network page of the dev tools:
  - Loading the homepage sends a request for to `[server-name]/api/sc2...` instead of `us.blizzard.api...`